### PR TITLE
Remove ActiveRecord Transaction

### DIFF
--- a/lib/onesie/overseer.rb
+++ b/lib/onesie/overseer.rb
@@ -14,14 +14,12 @@ module Onesie
     end
 
     def run_task(class_name, manual_override: false)
-      ActiveRecord::Base.transaction do
-        klass = Onesie::Tasks.const_get(class_name)
-        klass.class_eval { prepend Onesie::TaskWrapper }
-        klass.new.run(manual_override: manual_override)
-      rescue StandardError => e
-        puts error_message(class_name).red
-        raise e
-      end
+      klass = Onesie::Tasks.const_get(class_name)
+      klass.class_eval { prepend Onesie::TaskWrapper }
+      klass.new.run(manual_override: manual_override)
+    rescue StandardError => e
+      puts error_message(class_name).red
+      raise e
     end
 
     private


### PR DESCRIPTION
Remove the ActiveRecord Transaction from the Overseer. If a Task needs to be in a Transaction, it should be specified in the Task itself, not the runner.

This pull request branched off of the `add-manual-tasks` branch, which is still under review, hence the current target branch. I'll leave this as a draft until it is merged so I can continue development in the meantime.

***

Please ensure the following:

- [x] The PR relates to _only_ one subject with a clear title and description
- ~The changes are reflected in the CHANGELOG in the unreleased section~
- ~Reference the related issue if one exists, `Fix #[issue number]`~
