### PR TITLE
Move TaskWrapper helper methods to Task

### DIFF
--- a/lib/onesie/task.rb
+++ b/lib/onesie/task.rb
@@ -30,5 +30,31 @@ module Onesie
     def self.manual_task(enabled: false)
       define_method(:manual_task?) { enabled }
     end
+
+    private
+
+    # Returns the Task's class name
+    #
+    # @api private
+    # @return [String]
+    def class_name
+      self.class.name
+    end
+
+    # Creates a TaskRecord entry for the Task
+    #
+    # @api private
+    # @return [TaskRecord]
+    def record_task
+      TaskRecord.create!(task_name: class_name)
+    end
+
+    # Checks if this Task's TaskRecord is present in the database
+    #
+    # @api private
+    # @return [Boolean]
+    def task_record_present?
+      TaskRecord.find_by(task_name: class_name).present?
+    end
   end
 end

--- a/lib/onesie/task_wrapper.rb
+++ b/lib/onesie/task_wrapper.rb
@@ -16,19 +16,5 @@ module Onesie
       record_task
       puts 'Done!'.green
     end
-
-    private
-
-    def class_name
-      self.class.name
-    end
-
-    def record_task
-      TaskRecord.create!(task_name: class_name)
-    end
-
-    def task_record_present?
-      TaskRecord.find_by(task_name: class_name).present?
-    end
   end
 end


### PR DESCRIPTION
These helper methods were originally defined on the `TaskWrapper` before there was a `Task` class to inherit from. However, now that `Onesie::Task` exists, I think this is a more logical place for these methods. This limits the TaskWrapper to just `#run` which it is intended to wrap.

I thought about also removing the `TaskRecord` class and combining it with `Task`. However, it might be a good idea to keep `ActiveRecord` separate from our `Task` class.

***

Please ensure the following:

- [x] The PR relates to _only_ one subject with a clear title and description
- ~The changes are reflected in the CHANGELOG in the unreleased section~
- ~Reference the related issue if one exists, `Fix #[issue number]`~
