### PR TITLE
I24 - Update TaskWrapper to put Onesie name in Done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated documentation of manual tasks
 - Add documentation examples
+- Added Onesie task name to "Done" message for logging
 
 ### Deprecated
 

--- a/lib/onesie/task_wrapper.rb
+++ b/lib/onesie/task_wrapper.rb
@@ -14,7 +14,7 @@ module Onesie
       puts "Running #{name}...".magenta
       super()
       record_task
-      puts 'Done!'.green
+      puts "Done running #{name}!".green
     end
   end
 end


### PR DESCRIPTION
Fix #24 

Keeping track of log output in our logging platform when a Onesie
is finished may be difficult as we don't include what the name of the
Onesie was.

Adding the Onesie name to our 'Done!' output will assist with this.

***

Please ensure the following:

- [x] The PR relates to _only_ one subject with a clear title and description
- [x] The changes are reflected in the CHANGELOG in the unreleased section
- [x] Reference the related issue if one exists, `Fix #[issue number]`
