### PR TITLE
Add `.DS_Store` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 spec/examples.txt
 Gemfile.lock
 *.gem
+
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added `.DS_Store` to `.gitignore`
 
 ### Changed
 


### PR DESCRIPTION
Appears we're not ignoring `.DS_Store`. To prevent this file from being added, let's get it in `.gitignore`.

***

Please ensure the following:

- [x] The PR relates to _only_ one subject with a clear title and description
- [x] The changes are reflected in the CHANGELOG in the unreleased section
- [x] Reference the related issue if one exists, `Fix #[issue number]`
