### PR TITLE
Support Rails 5.2.8.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,7 +17,7 @@ Layout/EndAlignment:
 
 Layout/LineLength:
   Max: 100
-  IgnoredPatterns:
+  AllowedPatterns:
     - !ruby/regexp /\A +(it|describe|context|shared_examples|include_examples|it_behaves_like) ["']/
 
 Layout/MultilineMethodCallIndentation:
@@ -33,6 +33,11 @@ Metrics/BlockLength:
     - '**/*.rake'
     - 'Rakefile'
     - 'spec/**/*.rb'
+
+RSpec:
+  Language:
+    Expectations:
+      - assert_migration
 
 RSpec/MultipleExpectations:
   Max: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added `.DS_Store` to `.gitignore`
+- Added support for Rails version 5.2.8.1 and lower
 
 ### Changed
 

--- a/onesie.gemspec
+++ b/onesie.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-rspec',       '~> 2.5'
   spec.add_development_dependency 'sqlite3',             '~> 1.3.13'
 
-  spec.add_runtime_dependency 'activerecord', '>= 4.2.11.3', '<= 5.2.8'
+  spec.add_runtime_dependency 'activerecord', '>= 4.2.11.3', '<= 5.2.8.1'
   spec.add_runtime_dependency 'colorize',     '~> 0.8.1'
-  spec.add_runtime_dependency 'railties',     '>= 4.2.11.3', '<= 5.2.8'
+  spec.add_runtime_dependency 'railties',     '>= 4.2.11.3', '<= 5.2.8.1'
 end

--- a/onesie.gemspec
+++ b/onesie.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-rspec',       '~> 2.5'
   spec.add_development_dependency 'sqlite3',             '~> 1.3.13'
 
-  spec.add_runtime_dependency 'activerecord', '~> 4.2.11.3'
+  spec.add_runtime_dependency 'activerecord', '>= 4.2.11.3', '<= 5.2.8'
   spec.add_runtime_dependency 'colorize',     '~> 0.8.1'
-  spec.add_runtime_dependency 'railties',     '~> 4.2.11.3'
+  spec.add_runtime_dependency 'railties',     '>= 4.2.11.3', '<= 5.2.8'
 end


### PR DESCRIPTION
Adds support for Rails 5.2.8.1

***

Please ensure the following:

- [x] The PR relates to _only_ one subject with a clear title and description
- [x] The changes are reflected in the CHANGELOG in the unreleased section
- [x] Reference the related issue if one exists, `Fix #[issue number]`
