### PR TITLE
RSpec/IndexedLet

### DIFF
--- a/spec/onesie/runner_spec.rb
+++ b/spec/onesie/runner_spec.rb
@@ -18,13 +18,13 @@ RSpec.describe Onesie::Runner do
     end
 
     context 'with tasks out of version order' do
-      let(:task1) { instance_double(Onesie::TaskProxy, version: '20211122223807') }
-      let(:task2) { instance_double(Onesie::TaskProxy, version: '20211124224842') }
-      let(:task3) { instance_double(Onesie::TaskProxy, version: '20211125224842') }
-      let(:tasks) { [task2, task3, task1] }
+      let(:task_one) { instance_double(Onesie::TaskProxy, version: '20211122223807') }
+      let(:task_two) { instance_double(Onesie::TaskProxy, version: '20211124224842') }
+      let(:task_three) { instance_double(Onesie::TaskProxy, version: '20211125224842') }
+      let(:tasks) { [task_two, task_three, task_one] }
 
       it 'orders the task by version' do
-        expect(runner.tasks).to eq([task1, task2, task3])
+        expect(runner.tasks).to eq([task_one, task_two, task_three])
       end
     end
 


### PR DESCRIPTION
New Rubocop RSpec rule, `RSpec/IndexedLet`

***

Please ensure the following:

- [x] The PR relates to _only_ one subject with a clear title and description
- [ ] The changes are reflected in the CHANGELOG in the unreleased section
- [ ] Reference the related issue if one exists, `Fix #[issue number]`
